### PR TITLE
Increase build number to trigger new builds on windows.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install
 
 requirements:


### PR DESCRIPTION
Windows' py27 packages are missing.